### PR TITLE
Do not read bots' messages

### DIFF
--- a/src/classes/room.ts
+++ b/src/classes/room.ts
@@ -82,7 +82,9 @@ export default class Room {
 
     this.#messageCollector = textChannel.createMessageCollector({
       filter: (message) =>
-        message.cleanContent !== '' && !message.cleanContent.startsWith(';'),
+        message.cleanContent !== '' &&
+        !message.cleanContent.startsWith(';') &&
+        !message.author.bot,
     });
 
     this.#messageCollector.on('collect', (message) => {


### PR DESCRIPTION
同時に複数のメッセージを送るボットが入っていると死ぬので一時的にボットを読まないようにします。