### PR TITLE
Destroy when the last user goes to another VC

### DIFF
--- a/src/rooms.ts
+++ b/src/rooms.ts
@@ -67,7 +67,7 @@ export class RoomManager {
     }
     if (
       oldState.channelId === room.voiceChannel.id &&
-      newState.channelId === null && //disconnect
+      newState.channelId !== room.voiceChannel.id && //disconnect or channel switch
       room.voiceChannel.client.user?.id &&
       room.voiceChannel.members.has(room.voiceChannel.client.user?.id) &&
       room.voiceChannel.members.size === 1


### PR DESCRIPTION
現在の実装だと最後のユーザーがボイスチャンネルを切り替えてもボイスチャンネルに人がいなくなったとはみなされないので、切断ではなくチャンネル切り替えでも対応するようにします。